### PR TITLE
Add option to use the contrib binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This [Heroku buildpack][1] installs OpenTelemetry Collector in your Heroku dyno 
 
 This buildpack assumes that otel collector config file is located at `/otelcol/config.yml` in your application.
 
+By default, this buildpack installs [OpenTelemetry Collector Core][2], to install [OpenTelemetry Collector Contrib][3], set `OTELCOL_CONTRIB` to `true` in your enviroment variables.
+
 In addition, you can include a prerun script, `/otelcol/prerun.sh`, in your application. 
 The prerun script runs after all of the standard configuration actions and immediately before starting OpenTelemetry Collector. 
 This allows you to modify the environment variables (for example: $DISABLE_OTELCOL), perform additional configurations, etc.
@@ -26,9 +28,11 @@ fi
 
 ## Credits
 
-Most of the code and inspiration comes from the excellent [sendsonar's Prometheus Heroku Buildpack][2]
+Most of the code and inspiration comes from the excellent [sendsonar's Prometheus Heroku Buildpack][4]
 
 [1]: https://devcenter.heroku.com/articles/buildpacks
-[2]: https://github.com/sendsonar/heroku-buildpack-prometheus
+[2]: https://github.com/open-telemetry/opentelemetry-collector
+[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib
+[4]: https://github.com/sendsonar/heroku-buildpack-prometheus
 
 

--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,7 @@ ENV_DIR=$3
 BUILDPACK_DIR=$(cd "$(dirname "$0")"; cd ..; pwd)
 
 # Set pinned version
-PINNED_VERSION="0.39.0"
+PINNED_VERSION="0.43.0"
 
 # If a version hasn't been specified, use the pinned version
 if [ -f "$ENV_DIR/OTELCOL_VERSION" ]; then
@@ -26,21 +26,30 @@ else
   VERSION="$PINNED_VERSION"
 fi
 
+OTELCOL_BINARY="otelcol"
+# If the user hasn't request otelcol-contrib explicetely, use core
+if [ -f "$ENV_DIR/OTELCOL_CONTRIB" ]; then
+  OTELCOL_CONTRIB=$(cat "$ENV_DIR/OTELCOL_CONTRIB")
+  if [ "$OTELCOL_CONTRIB" == "true" ]; then
+    OTELCOL_BINARY="otelcol-contrib"
+  fi
+fi
+
 # Download
-if [ ! -f "$CACHE_DIR/otelcol-${VERSION}" ] || [ -n "$NOCACHE_OTELCOL" ]; then
+if [ ! -f "$CACHE_DIR/${OTELCOL_BINARY}-${VERSION}" ] || [ -n "$NOCACHE_OTELCOL" ]; then
   echo "-----> Installing v${VERSION} of OpenTelemetry Collector"
-  wget --quiet -O otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${VERSION}/otelcol_${VERSION}_linux_amd64.tar.gz
+  wget --quiet -O otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${VERSION}/${OTELCOL_BINARY}_${VERSION}_linux_amd64.tar.gz
   tar -xzf otelcol.tar.gz
 
-  rm -f "$CACHE_DIR/otelcol-*" || true
-  mv otelcol "$CACHE_DIR/otelcol-${VERSION}"
+  rm -f "$CACHE_DIR/${OTELCOL_BINARY}-*" || true
+  mv ${OTELCOL_BINARY} "$CACHE_DIR/${OTELCOL_BINARY}-${VERSION}"
 else
   echo "-----> OpenTelemetry Collector v${VERSION} found in cache"
 fi
 
 # Copy binaries
 mkdir -p "$BUILD_DIR/bin"
-cp "$CACHE_DIR/otelcol-${VERSION}" "$BUILD_DIR/bin/otelcol"
+cp "$CACHE_DIR/${OTELCOL_BINARY}-${VERSION}" "$BUILD_DIR/bin/otelcol"
 
 # Install the runner
 echo "-----> Installing OpenTelemetry Collector runner"


### PR DESCRIPTION
The Otel Collector binaries are now divided into "core" and "contrib", and most of the exporters are only available in the contrib release.

This PR adds an option to download contrib (defaulting to core) and updates the pinned version to the latest stable (0.43)