### PR TITLE
Fix prerun.sh example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This allows you to modify the environment variables (for example: $DISABLE_OTELC
 
 # Disable based on dyno type
 if [ "$DYNOTYPE" == "run" ]; then
-  $DISABLE_OTELCOL="true"
+  DISABLE_OTELCOL="true"
 fi
 
 # Update configuration placeholder using the Heroku application environment variable


### PR DESCRIPTION
We discovered this after copying the example to our app. Resulted in seeing
```
=true: command not found
```
on application startup.